### PR TITLE
Update test_cooccurrence.py

### DIFF
--- a/examples/test_cooccurrence.py
+++ b/examples/test_cooccurrence.py
@@ -27,29 +27,31 @@ if __name__ == '__main__':
                 documents.append(sentence)
 
     print(len(documents))
-    co = ptm.cooccurrence.CooccurrenceWorker()
-    co_result, vocab = co(documents)
-
+    ########################################################################################################################
+    cv = CountVectorizer()
+    cv_fit = cv.fit_transform(documents)
+    word_list = cv.get_feature_names()
+    count_list = cv_fit.toarray().sum(axis=0)
+    word_hist = dict(zip(word_list, count_list))
+    words = []
+    for word, freq in word_hist.items() :
+        for i in range(freq) :
+            words.append(word)
+    co = ptm.cooccurrence.CooccurrenceManager()
+    co_result, vocab = co.calculateCooccurrence(words)
+    print(str(co_result))
+    print(str(vocab)
+    ########################################################################################################################
     graph_builder = ptm.graphml.GraphMLCreator()
-    #mode is either with_threshold or without_threshod
-    mode='with_threshold'
+    # mode is either with_threshold or without_threshod
+    mode = 'with_threshold'
     if mode is 'without_threshold':
-        print(str(co_result))
-        print(str(vocab))
         graph_builder.createGraphML(co_result, vocab, "test1.graphml")
     elif mode is 'with_threshold':
-        cv = CountVectorizer()
-        cv_fit = cv.fit_transform(documents)
-        word_list = cv.get_feature_names();
-        count_list = cv_fit.toarray().sum(axis=0)
-        word_hist = dict(zip(word_list, count_list))
-
-        print(str(co_result))
-        print(str(word_hist))
-
-        graph_builder.createGraphMLWithThreshold(co_result, word_hist, vocab, "test.graphml",threshold=35.0)
-        display_limit=50
+        graph_builder.createGraphMLWithThreshold(co_result, word_hist, vocab, "test.graphml", threshold=35.0)
+        # 이 경우에만 그림을 그려보도록 하자
+        display_limit = 50
         graph_builder.summarize_centrality(limit=display_limit)
         title = '동시출현 기반 그래프'
-        file_name='test.png'
-        graph_builder.plot_graph(title,file=file_name)
+        file_name = 'test.png'
+        graph_builder.plot_graph(title, file=file_name)


### PR DESCRIPTION
다시 확인해 보니 코드가 잘못된 것이 아니라 예시가 잘못되었었습니다.
기존 예시는  40번째 줄이 ptm.cooccurrence.CooccurrenceWorker() 이었습니다.
이 class 의 경우에는 문서 내 단어를 모두 뽑아내는 작업이 init 파일 (선언 시)에 있습니다.

그러나 ptm.cooccurrence.CooccurrenceManager() 의 경우에는
즉 지금의 40번째 써 있는 것과 같은 class 로 하는 경우에는 선언부분에 이런 작업이 없습니다.
그러다 보니 모든 단어를 뽑는 것을 example 에서 해서 들어가야 합니다.
그 과정이 41번째 줄에서 일어나고 그 결과가 words 로, 41번째에서 매개변수로 input 으로 들어가는 것이며, 
그 것의 unique 한 값이 vocab 이라는 변수로 결과가 출력됩니다.

기존의 코드부분에서 CooccurrenceManager 클래스의 def calculateCooccurrence 를 보면 어떤 리스트가 input 으로 들어오는데
그게 document 라고 생각을 하면 오류가 나고
document 를 기반으로 만든 모든 워드 리스트라고 하면 기존 코드에서 문제 없이 돌아갑니다.

이에 따라서
1. example 의 예시를 순서를 조금 변경하고
2. 기존의 코드를 다시 살리며, 
3. 단, dictionary 부분에 오류가 있던 부분은 수정을 하는 방향
으로 가야 합니다.